### PR TITLE
Make generated struct be !Send & !Sync & !Unpin

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,28 @@
+#![no_std]
+
+#[doc(hidden)]
+pub use core as _core;
+
 #[macro_export]
 macro_rules! opaque {
     ($name:ident) => {
         #[repr(C)]
         pub struct $name {
-            _private: [*mut u8; 0]
+            // Required for FFI-safe 0-sized type.
+            //
+            // In the future, this should refer to an extern type.
+            // See https://github.com/rust-lang/rust/issues/43467.
+            _private: [u8; 0],
+
+            // Required for !Send & !Sync & !Unpin.
+            //
+            // - `*mut u8` is !Send & !Sync. It must be in `PhantomData` to not
+            //   affect alignment.
+            //
+            // - `PhantomPinned` is !Unpin. It must be in `PhantomData` because
+            //   its memory representation is not considered FFI-safe.
+            _pointer_marker:
+                $crate::_core::marker::PhantomData<(*mut u8, $crate::_core::marker::PhantomPinned)>,
         }
     };
 }
@@ -12,7 +31,7 @@ macro_rules! opaque {
 pub mod test {
     opaque!(test_t);
 
-    static_assertions::assert_not_impl_all!(test_t: Send, Sync, Unpin);
+    static_assertions::assert_not_impl_any!(test_t: Send, Sync, Unpin);
 
     #[deny(improper_ctypes, warnings)]
     extern "C" {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ macro_rules! opaque {
             //
             // In the future, this should refer to an extern type.
             // See https://github.com/rust-lang/rust/issues/43467.
-            _private: [u8; 0],
+            _data: [u8; 0],
 
             // Required for !Send & !Sync & !Unpin.
             //
@@ -21,7 +21,7 @@ macro_rules! opaque {
             //
             // - `PhantomPinned` is !Unpin. It must be in `PhantomData` because
             //   its memory representation is not considered FFI-safe.
-            _pointer_marker:
+            _marker:
                 $crate::_core::marker::PhantomData<(*mut u8, $crate::_core::marker::PhantomPinned)>,
         }
     };


### PR DESCRIPTION
This is done via a combination of `PhantomData`, `*mut u8`, and `PhantomPinned`.

Re-exported `core` to prevent failure if `core` refers to another module at the call site.

Also moved `*mut u8` out of the empty array and into `PhantomData`, because having it in the array makes the generated struct require alignment of `*mut u8`. This is dangerous because `&T` must always be properly aligned.

Corrected the static assertion to `assert_not_impl_any` to ensure that the generated type does not implement any of these autos traits.