### PR TITLE
Update syntax to enable attributes and visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ It uses an opaque struct to avoid leaking structural details of its database opt
 ```rust
 use ffi_opaque::opaque;
 
-opaque!(leveldb_options_t);
+opaque! {
+    /// Documentation works too!
+    pub struct leveldb_options_t;
+}
 
 extern "C" {
     pub fn leveldb_options_create() -> *mut leveldb_options_t;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,10 @@ pub use core as _core;
 /// ```rust
 /// use ffi_opaque::opaque;
 ///
-/// opaque!(leveldb_options_t);
+/// opaque! {
+///     /// And we can document the type.
+///     pub struct leveldb_options_t;
+/// }
 ///
 /// extern "C" {
 ///     pub fn leveldb_options_create() -> *mut leveldb_options_t;
@@ -37,9 +40,13 @@ pub use core as _core;
 /// ```
 #[macro_export]
 macro_rules! opaque {
-    ($name:ident) => {
+    (
+        $(#[$meta:meta])*
+        $vis:vis struct $name:ident;
+    ) => {
+        $(#[$meta])*
         #[repr(C)]
-        pub struct $name {
+        $vis struct $name {
             // Required for FFI-safe 0-sized type.
             //
             // In the future, this should refer to an extern type.
@@ -61,7 +68,9 @@ macro_rules! opaque {
 
 #[cfg(test)]
 pub mod test {
-    opaque!(test_t);
+    opaque! {
+        pub struct test_t;
+    }
 
     static_assertions::assert_not_impl_any!(test_t: Send, Sync, Unpin);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,10 +40,10 @@ pub use core as _core;
 /// ```
 #[macro_export]
 macro_rules! opaque {
-    (
+    ($(
         $(#[$meta:meta])*
         $vis:vis struct $name:ident;
-    ) => {
+    )+) => {$(
         $(#[$meta])*
         #[repr(C)]
         $vis struct $name {
@@ -63,7 +63,7 @@ macro_rules! opaque {
             _marker:
                 $crate::_core::marker::PhantomData<(*mut u8, $crate::_core::marker::PhantomPinned)>,
         }
-    };
+    )+};
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This syntax is the same as making a Rust zero-sized type, so it should be familiar.

Example:
```rust
opaque! {
    /// Documentation!!!
    pub struct leveldb_options_t;

    pub(crate) struct internal_t;

    struct priv_t;
}
```