### PR TITLE
Add homepage and repository links

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2018"
 license = "MIT"
 description = "A simple macro to create correct opaque pointers."
 documentation = "https://docs.rs/ffi-opaque/"
+homepage = "https://github.com/skade/ffi-opaque"
+repository = "https://github.com/skade/ffi-opaque"
 keywords = ["ffi", "macro", "safety"]
 categories = ["development-tools::ffi"]
 


### PR DESCRIPTION
This will make the repo much easier to find when discovering the crate on crates.io, docs.rs, or lib.rs.